### PR TITLE
Fix issue where container name is incorrectly generated when using docker swarm

### DIFF
--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -49,7 +49,7 @@ cat << EOF > ${HOME_DIR}/projects/${SCRIPT_NAME}.sh
 #!/usr/bin/env bash
 set -e
 
-CONTAINERS=\$(docker ps --format '{{.Names}}' | grep -E "^${PROJECT}_${CONTAINER}_[0-9]+")
+CONTAINERS=\$(docker ps --format '{{.Names}}' | grep -E "^${PROJECT}_${CONTAINER}.[0-9]+")
 for CONTAINER_NAME in \$CONTAINERS; do
     docker exec ${DOCKERARGS} \${CONTAINER_NAME} ${TMP_COMMAND}
 done


### PR DESCRIPTION
When using docker swarm I see container names such as the following:
`dev_backup.1.2mf3kktmlg5phoxyvfhzbfdnw`

This merge request changes the script from searching for names like `dev_backup_1`. Instead it greps for the name with a `.` in the place of the `_`.