### PR TITLE
fixed failure if docker group already existed

### DIFF
--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -23,9 +23,11 @@ CRONTAB_FILE=/etc/crontabs/docker
 mkdir -p ${HOME_DIR}/jobs ${HOME_DIR}/projects
 
 # Create docker group using correct gid from host, and add docker user to it
-DOCKER_GID=$(stat -c '%g' ${DOCKER_SOCK})
-addgroup -g ${DOCKER_GID} docker
-adduser docker docker
+if ! grep -q "^docker:" /etc/group; then
+	DOCKER_GID=$(stat -c '%g' ${DOCKER_SOCK})
+	addgroup -g ${DOCKER_GID} docker
+	adduser docker docker
+fi
 
 slugify() {
     echo "$@" | iconv -t ascii | sed -r s/[~\^]+//g | sed -r s/[^a-zA-Z0-9]+/-/g | sed -r s/^-+\|-+$//g | tr A-Z a-z


### PR DESCRIPTION
This error was preventing the container from restarting.