### PR TITLE
Fix issue "ambiguous redirect"

### DIFF
--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -49,6 +49,7 @@ make_container_cmd() {
     DOCKERARGS=$(echo ${1} | jq -r .dockerargs)
     if [ "${DOCKERARGS}" == "null" ]; then DOCKERARGS=; fi
     SCRIPT_NAME=$(echo ${1} | jq -r .name)
+    SCRIPT_NAME=$(slugify $SCRIPT_NAME)
     PROJECT=$(echo ${1} | jq -r .project)
     CONTAINER=$(echo ${1} | jq -r .container)
     TMP_COMMAND=$(echo ${1} | jq -r .command)


### PR DESCRIPTION
Full error message: _/docker-entrypoint.sh: line 58: ${HOME_DIR}/projects/${SCRIPT_NAME}.sh: ambiguous redirect_

The error appears when in _Config.json_ is present `name` and `container`, and the initial part of `name` is repeated in more than one cron jobs.
```
[
    {
    "name": "My cron job1",
    [...]
    "container": "sphinx",
    },
    {
    "name": "My cron job2",
    [...]
    "container": "sphinx",
    }
]
```