### PR TITLE
Added support for envsubst in image/container name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM library/docker:stable
 
 ENV HOME_DIR=/opt/crontab
-RUN apk add --no-cache --virtual .run-deps bash jq \
+RUN apk add --no-cache --virtual .run-deps gettext bash jq \
     && mkdir -p ${HOME_DIR}/jobs ${HOME_DIR}/projects \
     && adduser -S docker -D
 

--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -12,7 +12,7 @@ if [ "${LOG_FILE}" == "" ]; then
     LOG_DIR=/var/log/crontab
 	LOG_FILE=${LOG_DIR}/jobs.log
 	mkdir -p ${LOG_DIR}
-	touch ${LOG_FILE}
+    touch ${LOG_FILE}
 fi
 
 CONFIG=${HOME_DIR}/config.json
@@ -40,7 +40,7 @@ slugify() {
 make_image_cmd() {
     DOCKERARGS=$(echo ${1} | jq -r .dockerargs)
     if [ "${DOCKERARGS}" == "null" ]; then DOCKERARGS=; fi
-    IMAGE=$(echo ${1} | jq -r .image)
+    IMAGE=$(echo ${1} | jq -r .image | envsubst)
     TMP_COMMAND=$(echo ${1} | jq -r .command)
     echo "docker run ${DOCKERARGS} ${IMAGE} ${TMP_COMMAND}"
 }
@@ -50,7 +50,7 @@ make_container_cmd() {
     if [ "${DOCKERARGS}" == "null" ]; then DOCKERARGS=; fi
     SCRIPT_NAME=$(echo ${1} | jq -r .name)
     PROJECT=$(echo ${1} | jq -r .project)
-    CONTAINER=$(echo ${1} | jq -r .container)
+    CONTAINER=$(echo ${1} | jq -r .container | envsubst)
     TMP_COMMAND=$(echo ${1} | jq -r .command)
 
     if [ "${PROJECT}" != "null" ]; then


### PR DESCRIPTION
The `envsubst` allows to use dynamic container name
We use image name substitution from environment with docker-compose and .env to select right image tag for local development
* it's look like `"image": "harbor.company.com/my-app:${MY_APP}"` in docker-crontab `config.json`
* `docker-compose.yml` looks like this:
```yaml
image:
   "harbor.company.com/my-app:${MY_APP:-master}"
env:
  MY_APP: ${MY_APP}
```
The `MY_APP` variable is defined in `.env` - which is [supported by docker-compose](https://docs.docker.com/compose/env-file/)
The `.env` file is generated by our CI/CD system.

So the `envsubst` looks like ideal way to use variable image tag for us.

Within alpine, envsubst installed with gettext package - so I've added `apk add gettext` do Dockerfile.