### PR TITLE
Improve crond command in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ ENTRYPOINT ["/docker-entrypoint"]
 HEALTHCHECK --interval=5s --timeout=3s \
     CMD ps aux | grep '[c]rond' || exit 1
 
-CMD ["crond", "-f", "-d", "0", "-c", "/etc/crontabs"]
+CMD ["crond", "-f", "-d", "6", "-c", "/etc/crontabs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ ENTRYPOINT ["/docker-entrypoint"]
 HEALTHCHECK --interval=5s --timeout=3s \
     CMD ps aux | grep '[c]rond' || exit 1
 
-CMD ["crond","-f"]
+CMD ["crond", "-f", "-d", "0", "-c", "/etc/crontabs"]


### PR DESCRIPTION
* run with /etc/crontabs dir to ensure that crontabs are parsed
* crond will log to docker logs (`-d 6` option)
  * for busybox cron level 6 is enough to see errors and hide debug info
  * debug info shown at level 5
  * nothing shown at levels 0, 1, 2, 3, 4