### PR TITLE
Fix use of 'ensure_docker_socket_accessible' when using DOCKER_HOST

### DIFF
--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -259,7 +259,10 @@ EOF
 }
 
 
-ensure_docker_socket_accessible
+if [ -z "$DOCKER_HOST" ]; then
+    echo "Testing docker socket accessibility"
+    ensure_docker_socket_accessible
+fi
 
 start_app() {
     get_config


### PR DESCRIPTION
This PR makes the call to ```ensure_docker_socket_accessible``` only when DOCKER_HOST is not set. 
This fixes issue #46.