### PR TITLE
Use yj instead of rq, and support ARM architecture

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,13 @@
-FROM alpine:3.12 as rq-build
+FROM golang:1.14-alpine as yj-build
 
-ENV RQ_VERSION=1.0.2
-WORKDIR /root/
-
-RUN apk --update add upx \
-    && wget https://github.com/dflemstr/rq/releases/download/v${RQ_VERSION}/rq-v${RQ_VERSION}-x86_64-unknown-linux-musl.tar.gz \
-    && tar -xvf rq-v1.0.2-x86_64-unknown-linux-musl.tar.gz \
-    && upx --brute rq
+WORKDIR /build
+RUN apk add git \
+    && git clone https://github.com/sclevine/yj.git && cd yj \
+    && go build
 
 FROM library/docker:stable
 
-COPY --from=rq-build /root/rq /usr/local/bin
+COPY --from=yj-build /build/yj/yj /usr/local/bin
 
 ENV HOME_DIR=/opt/crontab
 RUN apk add --no-cache --virtual .run-deps gettext jq bash tini \

--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -19,11 +19,11 @@ get_config() {
     if [ -f "${HOME_DIR}/config.json" ]; then
         jq 'map(.)' ${HOME_DIR}/config.json > ${HOME_DIR}/config.working.json
     elif [ -f "${HOME_DIR}/config.toml" ]; then
-        rq -t <<< $(cat ${HOME_DIR}/config.toml) | jq 'map(.)' > ${HOME_DIR}/config.json
+        yj -t < ${HOME_DIR}/config.toml | jq 'map(.)' > ${HOME_DIR}/config.json
     elif [ -f "${HOME_DIR}/config.yml" ]; then
-        rq -y <<< $(cat ${HOME_DIR}/config.yml) | jq 'map(.)' > ${HOME_DIR}/config.json
+        yj -y <  ${HOME_DIR}/config.yml | jq 'map(.)' > ${HOME_DIR}/config.json
     elif [ -f "${HOME_DIR}/config.yaml" ]; then
-        rq -y <<< $(cat ${HOME_DIR}/config.yaml) | jq 'map(.)' > ${HOME_DIR}/config.json
+        yj -y < ${HOME_DIR}/config.yaml | jq 'map(.)' > ${HOME_DIR}/config.json
     fi
 }
 


### PR DESCRIPTION
When docker build on M1 Mac, the rq command will cause segmentation fault.
```
# rq --version
qemu: uncaught target signal 11 (Segmentation fault) - core dumped
Segmentation fault
```

Change to support the ARM architecture using yj instead of rq.