### PR TITLE
fix: project - container separator in script from '_' to any single c…

### DIFF
--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -100,7 +100,7 @@ cat << EOF > ${HOME_DIR}/projects/${SCRIPT_NAME}.sh
 #!/usr/bin/env bash
 set -e
 
-CONTAINERS=\$(docker ps --format '{{.Names}}' | grep -E "^${PROJECT}_${CONTAINER}.[0-9]+")
+CONTAINERS=\$(docker ps --format '{{.Names}}' | grep -E "^${PROJECT}.${CONTAINER}.[0-9]+")
 for CONTAINER_NAME in \$CONTAINERS; do
     docker exec ${DOCKERARGS} \${CONTAINER_NAME} ${TMP_COMMAND}
 done


### PR DESCRIPTION
…haracter

As 'docker-compose' v2 and 'docker compose' also uses dash instead of underscore in naming containers, changed the _ to . in regexp to match any character.

#62 